### PR TITLE
Run ActiveRecord's quoting machinery

### DIFF
--- a/lib/active_record/connection_adapters/bigquery_adapter.rb
+++ b/lib/active_record/connection_adapters/bigquery_adapter.rb
@@ -84,7 +84,7 @@ module ActiveRecord
     private
     # Creates a record with values matching those of the instance attributes
     # and returns its id.
-    def create_record(attribute_names = @attributes.keys)  
+    def _create_record(attribute_names = @attributes.keys)
       record_timestamps_hardcoded
       attributes_values = self.changes.values.map(&:last).map!{|v| self.class.connection.quote v }
             
@@ -108,6 +108,9 @@ module ActiveRecord
       @new_record = false
       id
     end
+
+    # Backward compatibility with older versions of ActiveRecord
+    alias_method :create_record, :_create_record
 
     #Partially copied from activerecord::Timezones
     def record_timestamps_hardcoded


### PR DESCRIPTION
Date, DateTime and Time objects are always converted to the format acceptable by BigQuery with this change.
This change also disables the actual quoting of strings - this is not needed as the JSON serializer does this.

@michelson, I was also thinking about a small optimization - we can skip running Base::quote() in line #89 for values that are strings (and maybe other types too). The code is clearer now and harmonised with ActiveRecord's flow, but does unnecessary things.

Edit: I've just added a second commit - BigBroda doesn't work with the newest ActiveRecord, this change fixes it.
