### PR TITLE
getQueryResults and list methods were passing a request body instead of ...

### DIFF
--- a/lib/google_bigquery/jobs.rb
+++ b/lib/google_bigquery/jobs.rb
@@ -27,11 +27,10 @@ module GoogleBigquery
     end
 
     #Retrieves the results of a query job.
-    def self.getQueryResults(project_id , job_id, body={})
+    def self.getQueryResults(project_id , job_id, params={})
       res = GoogleBigquery::Auth.client.execute(
         :api_method=> GoogleBigquery::Auth.api.jobs.get_query_results, 
-        :body_object=> body, 
-        :parameters=> {"projectId"=> project_id, "jobId"=>job_id}
+        :parameters=> {"projectId"=> project_id, "jobId"=>job_id}.merge(params)
       )
       parse_response(res)
     end
@@ -47,11 +46,10 @@ module GoogleBigquery
     end
 
     #Lists all the Jobs in the specified project that were started by the user.
-    def self.list(project_id, body={})
+    def self.list(project_id, params={})
       res = GoogleBigquery::Auth.client.execute(
         :api_method=> GoogleBigquery::Auth.api.jobs.list, 
-        :body_object=> body, 
-        :parameters=> {"projectId"=> project_id}
+        :parameters=> {"projectId"=> project_id}.merge(params)
       )
       parse_response(res)
     end


### PR DESCRIPTION
...using parameters, which caused a server error. Fixed now so you can pass parameters instead of a request body

As seen on https://developers.google.com/bigquery/docs/reference/v2/jobs/getQueryResults and https://developers.google.com/bigquery/docs/reference/v2/jobs/list, BigQuery's API doesn't support a request body for these two methods, and you must provider all the parameters as query parameters, rather than the body object.

This was breaking the getQueryResults and list methods in jobs. With this commit, you can list all the jobs in a project and you can paginate queries, or get results from timed-out ones.
